### PR TITLE
Change target names as new MTB namings

### DIFF
--- a/lora_radio_helper.cpp
+++ b/lora_radio_helper.cpp
@@ -70,7 +70,7 @@ static SX1276_LoRaRadio radio(LORA_SPI_MOSI, LORA_SPI_MISO, LORA_SPI_SCLK, LORA_
  * available on WISE-1510 module
  * http://www.advantech.com/products/ed549ce6-ff1b-4f36-a350-2ecabeb2418a/wise-1510/mod_5904a91b-0a62-4d34-97f6-b5c6b2c1ac91
  */
-#if TARGET_WISE_1510
+#if TARGET_MTB_ADV_WISE_1510
 #define LORA_SPI_MOSI   PB_5
 #define LORA_SPI_MISO   PB_4
 #define LORA_SPI_SCK    PB_3
@@ -87,7 +87,7 @@ static SX1276_LoRaRadio radio(LORA_SPI_MOSI, LORA_SPI_MISO, LORA_SPI_SCLK, LORA_
 static SX1276_LoRaRadio radio(LORA_SPI_MOSI, LORA_SPI_MISO, LORA_SPI_SCK, LORA_CS, LORA_RESET,
                               LORA_DIO0, LORA_DIO1, LORA_DIO2, LORA_DIO3, LORA_DIO4, LORA_DIO5,
                               NC, NC, NC, NC, LORA_ANT_SWITCH, NC, NC);
-#endif //TARGET_WISE_1510
+#endif //TARGET_MTB_ADV_WISE_1510
 
 /**
  * Constructing a LoRaRadio object for Semtech 1276 radio
@@ -95,7 +95,7 @@ static SX1276_LoRaRadio radio(LORA_SPI_MOSI, LORA_SPI_MISO, LORA_SPI_SCK, LORA_C
  * https://www.murata.com/en-eu/products/lpwa/lora
  * https://os.mbed.com/platforms/ST-Discovery-LRWAN1/
  */
-#if defined(TARGET_DISCO_L072CZ_LRWAN1) || defined(TARGET_CMWX1ZZABZ_078)
+#if defined(TARGET_DISCO_L072CZ_LRWAN1) || defined(TARGET_MTB_MURATA_ABZ)
 #define LORA_SPI_MOSI   PA_7
 #define LORA_SPI_MISO   PA_6
 #define LORA_SPI_SCLK   PB_3


### PR DESCRIPTION
To be merged after mbed-os 1c5c1c79d0b518aec629004be19f7fd1fd62fb8e has been taken into use